### PR TITLE
Add example for custom timeout

### DIFF
--- a/api/query.md
+++ b/api/query.md
@@ -19,7 +19,8 @@ const util = require('minecraft-server-util');
 
 const options = {
     sessionID: 1, // a random 32-bit signed number, optional
-    enableSRV: true // SRV record lookup
+    enableSRV: true, // SRV record lookup
+    timeout: 3000 // Timeout, in milliseconds, optional. Defaults to 5000.
 };
 
 // The port and options arguments are optional, the
@@ -58,7 +59,8 @@ const util = require('minecraft-server-util');
 
 const options = {
     sessionID: 1, // a random 32-bit signed number, optional
-    enableSRV: true // SRV record lookup
+    enableSRV: true, // SRV record lookup
+    timeout: 3000 // Timeout, in milliseconds, optional. Defaults to 5000.
 };
 
 // The port and options arguments are optional, the


### PR DESCRIPTION
Add missing information about the `timeout` option that caused confusion in [minecraft-server-util issue #76](https://github.com/PassTheMayo/minecraft-server-util/issues/76).